### PR TITLE
Add textFormatter and textMatcher in COLUMN_MAYBE_FUNCTIONS

### DIFF
--- a/src/lib/utils/propCategories.js
+++ b/src/lib/utils/propCategories.js
@@ -210,6 +210,8 @@ export const COLUMN_MAYBE_FUNCTIONS = {
 
     // Columns: Filter
     getQuickFilterText: 1,
+    textFormatter: 1,
+    textMatcher: 1,
 
     // Columns: Headers
     suppressHeaderKeyboardEvent: 1,

--- a/tests/assets/dashAgGridFunctions.js
+++ b/tests/assets/dashAgGridFunctions.js
@@ -355,3 +355,40 @@ dagfuncs.contextTest = (params) => {
     ];
     return result;
 };
+
+// FOR test_custom_filter.py
+dagfuncs.myTextFormatter = (text) => {
+  if (text == null) return null;
+  return text
+    .toLowerCase()
+    .replace(/[àáâãäå]/g, 'a')
+    .replace(/æ/g, 'ae')
+    .replace(/ç/g, 'c')
+    .replace(/[èéêë]/g, 'e')
+    .replace(/[ìíîï]/g, 'i')
+    .replace(/ñ/g, 'n')
+    .replace(/[òóôõö]/g, 'o')
+    .replace(/œ/g, 'oe')
+    .replace(/[ùúûü]/g, 'u')
+    .replace(/[ýÿ]/g, 'y');
+}
+
+function contains(target, lookingFor) {
+  return target && target.indexOf(lookingFor) >= 0;
+}
+
+dagfuncs.myTextMatcher = ({value, filterText}) => {
+  const aliases = {
+    usa: "united states",
+    holland: "netherlands",
+    niall: "ireland",
+    sean: "south africa",
+    alberto: "mexico",
+    john: "australia",
+    xi: "china",
+  };
+  const literalMatch = contains(value, filterText || "");
+  return literalMatch || contains(value, aliases[filterText || ""]);
+}
+// END test_custom_filter.py
+

--- a/tests/examples/assets/dashAgGridFunctions.js
+++ b/tests/examples/assets/dashAgGridFunctions.js
@@ -1,7 +1,42 @@
 var dagfuncs = window.dashAgGridFunctions = window.dashAgGridFunctions || {};
-dagfuncs.Round = function(v, a=2) {
-    return Math.round(v * (10**a)) / (10**a)
+dagfuncs.Round = function (v, a = 2) {
+  return Math.round(v * (10 ** a)) / (10 ** a)
 }
 
-dagfuncs.toFixed = function(v, a=2) {
-    return Number(v).toFixed(a)
+dagfuncs.toFixed = function (v, a = 2) {
+  return Number(v).toFixed(a)
+}
+
+dagfuncs.myTextFormatter = (text) => {
+  if (text == null) return null;
+  return text
+    .toLowerCase()
+    .replace(/[àáâãäå]/g, 'a')
+    .replace(/æ/g, 'ae')
+    .replace(/ç/g, 'c')
+    .replace(/[èéêë]/g, 'e')
+    .replace(/[ìíîï]/g, 'i')
+    .replace(/ñ/g, 'n')
+    .replace(/[òóôõö]/g, 'o')
+    .replace(/œ/g, 'oe')
+    .replace(/[ùúûü]/g, 'u')
+    .replace(/[ýÿ]/g, 'y');
+}
+
+function contains(target, lookingFor) {
+  return target && target.indexOf(lookingFor) >= 0;
+}
+
+dagfuncs.myTextMatcher = ({value, filterText}) => {
+  const aliases = {
+    usa: "united states",
+    holland: "netherlands",
+    niall: "ireland",
+    sean: "south africa",
+    alberto: "mexico",
+    john: "australia",
+    xi: "china",
+  };
+  const literalMatch = contains(value, filterText || "");
+  return literalMatch || contains(value, aliases[filterText || ""]);
+}

--- a/tests/examples/filter_params.py
+++ b/tests/examples/filter_params.py
@@ -1,0 +1,37 @@
+# Example to test textFormatter and filterParams functions in filterParams
+
+import dash_ag_grid as dag
+from dash import Dash, html
+import pandas as pd
+
+app = Dash(__name__)
+
+df = pd.read_csv(
+    "https://raw.githubusercontent.com/plotly/datasets/master/ag-grid/olympic-winners.csv"
+)
+
+columnDefs = [
+    {
+        "field": "athlete",
+        "filterParams": {"textFormatter": {"function": "myTextFormatter(params)"}},
+    },
+    {
+        "field": "country",
+        "filterParams": {"textMatcher": {"function": "myTextMatcher(params)"}},
+    },
+]
+
+app.layout = html.Div(
+    [
+        dag.AgGrid(
+            id="text-filter-custom",
+            rowData=df.to_dict("records"),
+            columnDefs=columnDefs,
+            columnSize="sizeToFit",
+            defaultColDef={"filter": True, "floatingFilter": True}
+        ),
+    ]
+)
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
`columnDefs.filterParams` is in COLUMN_NESTED_OR_OBJ_OF_FUNCTIONS so it is possible to use a JS function to configure it.

But instead of setting the full `filterParams` in JS, we can use JS functions for `filterParams.textFormatter` and `filterParams.textMatcher` only like:

```python
    {
        "field": "athlete",
        "filterParams": {
            "filterOptions": ["contains", "notContains"],
            "textFormatter": {"function": "myTextFormatter(params)"},
            "debounceMs": 200,
            "maxNumConditions": 1,
        },
    },
```

by adding those params in COLUMN_MAYBE_FUNCTIONS

Thoughts? 🙂