### PR TITLE
Add quartz theme, modify ag-grid version to 31.0.1 and add properties to be allowed to use as function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
     "name": "dash-ag-grid",
-    "version": "2.4.0",
+    "version": "31.0.1rc3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dash-ag-grid",
-            "version": "2.4.0",
+            "version": "31.0.1rc3",
             "license": "MIT",
             "dependencies": {
                 "@emotion/react": "^11.11.1",
                 "@emotion/styled": "^11.11.0",
                 "@mui/icons-material": "^5.14.14",
                 "@mui/material": "^5.14.14",
-                "ag-grid-community": "^31.0.0",
-                "ag-grid-enterprise": "^31.0.0",
-                "ag-grid-react": "^31.0.0",
+                "ag-grid-community": "^31.0.1",
+                "ag-grid-enterprise": "^31.0.1",
+                "ag-grid-react": "^31.0.1",
                 "d3-format": "^3.1.0",
                 "d3-time": "^3.1.0",
                 "d3-time-format": "^4.1.0",
@@ -3056,24 +3056,24 @@
             }
         },
         "node_modules/ag-grid-community": {
-            "version": "31.0.0",
-            "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.0.0.tgz",
-            "integrity": "sha512-OUrXSAbLs0s5DTL9G/J626IKF2mzENHtLzLo5SV0RMO34ZzQANZd1mWlahT0uhZyUFnhyyEEecJBE5nSI88VEw=="
+            "version": "31.0.1",
+            "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.0.1.tgz",
+            "integrity": "sha512-RZQlW1DTOJHsUR/tnbnTJQKgAnDlHi05YYyTe5AgNor/1TlX1hoYdcqrGsJjvcHQgTjeEgzWOL0yf+KcqXZzxg=="
         },
         "node_modules/ag-grid-enterprise": {
-            "version": "31.0.0",
-            "resolved": "https://registry.npmjs.org/ag-grid-enterprise/-/ag-grid-enterprise-31.0.0.tgz",
-            "integrity": "sha512-upYw/eeMMqM6TQsOgbAGItSS+x74Spsub8jqqyrozPry8l1UgLmq8TetBrfQ9neS5q8MQpRTHJbXWS3+Gdbo5g==",
+            "version": "31.0.1",
+            "resolved": "https://registry.npmjs.org/ag-grid-enterprise/-/ag-grid-enterprise-31.0.1.tgz",
+            "integrity": "sha512-VAL6np/dDBywZSOcIyssSj9IEzN+FsKSOrDD5V97P7fiPLE2RWNPuaj/5cLOUuuelUpffu6KK2/9U6KFBVmXoA==",
             "dependencies": {
-                "ag-grid-community": "~31.0.0"
+                "ag-grid-community": "~31.0.1"
             }
         },
         "node_modules/ag-grid-react": {
-            "version": "31.0.0",
-            "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.0.0.tgz",
-            "integrity": "sha512-lrcsPNggFdkbDApQG8sFhVu8Bd2E6GbwVJKugxhjg4y/fVayctb7NOmp8wQde8mt288vSKFtwoXJWicBB2k8uw==",
+            "version": "31.0.1",
+            "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.0.1.tgz",
+            "integrity": "sha512-9nmYPsgH1YUDUDOTiyaFsysoNAx/y72ovFJKuOffZC1V7OrQMadyP6DbqGFWCqzzoLJOY7azOr51dDQzAIXLpw==",
             "dependencies": {
-                "ag-grid-community": "~31.0.0",
+                "ag-grid-community": "~31.0.1",
                 "prop-types": "^15.8.1"
             },
             "peerDependencies": {
@@ -12875,24 +12875,24 @@
             "requires": {}
         },
         "ag-grid-community": {
-            "version": "31.0.0",
-            "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.0.0.tgz",
-            "integrity": "sha512-OUrXSAbLs0s5DTL9G/J626IKF2mzENHtLzLo5SV0RMO34ZzQANZd1mWlahT0uhZyUFnhyyEEecJBE5nSI88VEw=="
+            "version": "31.0.1",
+            "resolved": "https://registry.npmjs.org/ag-grid-community/-/ag-grid-community-31.0.1.tgz",
+            "integrity": "sha512-RZQlW1DTOJHsUR/tnbnTJQKgAnDlHi05YYyTe5AgNor/1TlX1hoYdcqrGsJjvcHQgTjeEgzWOL0yf+KcqXZzxg=="
         },
         "ag-grid-enterprise": {
-            "version": "31.0.0",
-            "resolved": "https://registry.npmjs.org/ag-grid-enterprise/-/ag-grid-enterprise-31.0.0.tgz",
-            "integrity": "sha512-upYw/eeMMqM6TQsOgbAGItSS+x74Spsub8jqqyrozPry8l1UgLmq8TetBrfQ9neS5q8MQpRTHJbXWS3+Gdbo5g==",
+            "version": "31.0.1",
+            "resolved": "https://registry.npmjs.org/ag-grid-enterprise/-/ag-grid-enterprise-31.0.1.tgz",
+            "integrity": "sha512-VAL6np/dDBywZSOcIyssSj9IEzN+FsKSOrDD5V97P7fiPLE2RWNPuaj/5cLOUuuelUpffu6KK2/9U6KFBVmXoA==",
             "requires": {
-                "ag-grid-community": "~31.0.0"
+                "ag-grid-community": "~31.0.1"
             }
         },
         "ag-grid-react": {
-            "version": "31.0.0",
-            "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.0.0.tgz",
-            "integrity": "sha512-lrcsPNggFdkbDApQG8sFhVu8Bd2E6GbwVJKugxhjg4y/fVayctb7NOmp8wQde8mt288vSKFtwoXJWicBB2k8uw==",
+            "version": "31.0.1",
+            "resolved": "https://registry.npmjs.org/ag-grid-react/-/ag-grid-react-31.0.1.tgz",
+            "integrity": "sha512-9nmYPsgH1YUDUDOTiyaFsysoNAx/y72ovFJKuOffZC1V7OrQMadyP6DbqGFWCqzzoLJOY7azOr51dDQzAIXLpw==",
             "requires": {
-                "ag-grid-community": "~31.0.0",
+                "ag-grid-community": "~31.0.1",
                 "prop-types": "^15.8.1"
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dash-ag-grid",
-    "version": "2.4.0",
+    "version": "31.0.1rc3",
     "description": "Dash wrapper around AG Grid, the best interactive data grid for the web.",
     "repository": {
         "type": "git",
@@ -29,9 +29,9 @@
     "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "ag-grid-community": "^31.0.0",
-        "ag-grid-enterprise": "^31.0.0",
-        "ag-grid-react": "^31.0.0",
+        "ag-grid-community": "^31.0.1",
+        "ag-grid-enterprise": "^31.0.1",
+        "ag-grid-react": "^31.0.1",
         "@mui/icons-material": "^5.14.14",
         "@mui/material": "^5.14.14",
         "d3-format": "^3.1.0",

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -922,7 +922,14 @@ export default class DashAgGrid extends Component {
         });
     }
 
-    onCellValueChanged({oldValue, value, column: {colId}, rowIndex, data, node}) {
+    onCellValueChanged({
+        oldValue,
+        value,
+        column: {colId},
+        rowIndex,
+        data,
+        node,
+    }) {
         const timestamp = Date.now();
         // Collect new change.
         const newChange = {

--- a/src/lib/fragments/AgGrid.react.js
+++ b/src/lib/fragments/AgGrid.react.js
@@ -53,11 +53,13 @@ import 'ag-grid-community/styles/ag-grid.css';
 import 'ag-grid-community/styles/ag-theme-alpine.css';
 import 'ag-grid-community/styles/ag-theme-balham.css';
 import 'ag-grid-community/styles/ag-theme-material.css';
+import 'ag-grid-community/styles/ag-theme-quartz.css';
 
 // d3 imports
 import * as d3Format from 'd3-format';
 import * as d3Time from 'd3-time';
 import * as d3TimeFormat from 'd3-time-format';
+
 const d3 = {...d3Format, ...d3Time, ...d3TimeFormat};
 
 // Rate-limit for resizing columns when grid div is resized
@@ -920,14 +922,7 @@ export default class DashAgGrid extends Component {
         });
     }
 
-    onCellValueChanged({
-        oldValue,
-        value,
-        column: {colId},
-        rowIndex,
-        data,
-        node,
-    }) {
+    onCellValueChanged({oldValue, value, column: {colId}, rowIndex, data, node}) {
         const timestamp = Date.now();
         // Collect new change.
         const newChange = {
@@ -1256,6 +1251,7 @@ export default class DashAgGrid extends Component {
             this.syncRowData();
         }
     }
+
     // end event actions
 
     updateColumnState() {

--- a/src/lib/utils/propCategories.js
+++ b/src/lib/utils/propCategories.js
@@ -67,6 +67,7 @@ export const GRID_MAYBE_FUNCTIONS = {
     // Filtering
     isExternalFilterPresent: 1,
     doesExternalFilterPass: 1,
+    quickFilterParser: 1,
 
     // Integrated Charts
     getChartToolbarItems: 1,
@@ -139,6 +140,7 @@ export const GRID_MAYBE_FUNCTIONS_NO_PARAMS = {
     setPopupParent: 1,
     popupParent: 1,
     dataTypeDefinitions: 1,
+    quickFilterMatcher: 1,
 };
 
 /**
@@ -183,6 +185,9 @@ export const COLUMN_MAYBE_FUNCTIONS_NO_PARAMS = {
     // Columns: Sort
     comparator: 1,
     dataTypeMatcher: 1,
+
+    // filter params custom option
+    predicate: 1,
 };
 
 /**
@@ -212,6 +217,8 @@ export const COLUMN_MAYBE_FUNCTIONS = {
     getQuickFilterText: 1,
     textFormatter: 1,
     textMatcher: 1,
+    numberFormatter: 1,
+    numberParser: 1,
 
     // Columns: Headers
     suppressHeaderKeyboardEvent: 1,
@@ -257,9 +264,8 @@ export const COLUMN_MAYBE_FUNCTIONS = {
     // Header Group Component Parameters
     setExpanded: 1,
 
-    // In filterParams or filterParams.filterOptions[]
+    // In filterParams
     filterPlaceholder: 1,
-    predicate: 1,
 };
 
 /**

--- a/tests/assets/dashAgGridFunctions.js
+++ b/tests/assets/dashAgGridFunctions.js
@@ -390,5 +390,21 @@ dagfuncs.myTextMatcher = ({value, filterText}) => {
   const literalMatch = contains(value, filterText || "");
   return literalMatch || contains(value, aliases[filterText || ""]);
 }
+
+dagfuncs.myNumberParser = (text) => {
+  return text === null ? null : parseFloat(text.replace(",", ".").replace("$", ""));
+}
+dagfuncs.myNumberFormatter = (value) => {
+  return value === null ? null : value.toString().replace(".", ",");
+}
+dagfuncs.startWith = ([filterValues], cellValue) => {
+    const name = cellValue ? cellValue.split(" ")[1] : ""
+    return name && name.toLowerCase().indexOf(filterValues.toLowerCase()) === 0
+}
 // END test_custom_filter.py
 
+// FOR test_quick_filter.py
+dagfuncs.quickFilterMatcher = (quickFilterParts, rowQuickFilterAggregateText) => {
+    return quickFilterParts.every(part => rowQuickFilterAggregateText.match(part));
+}
+// END test_custom_filter.py

--- a/tests/examples/assets/dashAgGridFunctions.js
+++ b/tests/examples/assets/dashAgGridFunctions.js
@@ -1,42 +1,58 @@
 var dagfuncs = window.dashAgGridFunctions = window.dashAgGridFunctions || {};
 dagfuncs.Round = function (v, a = 2) {
-  return Math.round(v * (10 ** a)) / (10 ** a)
+    return Math.round(v * (10 ** a)) / (10 ** a)
 }
 
 dagfuncs.toFixed = function (v, a = 2) {
-  return Number(v).toFixed(a)
+    return Number(v).toFixed(a)
 }
 
 dagfuncs.myTextFormatter = (text) => {
-  if (text == null) return null;
-  return text
-    .toLowerCase()
-    .replace(/[àáâãäå]/g, 'a')
-    .replace(/æ/g, 'ae')
-    .replace(/ç/g, 'c')
-    .replace(/[èéêë]/g, 'e')
-    .replace(/[ìíîï]/g, 'i')
-    .replace(/ñ/g, 'n')
-    .replace(/[òóôõö]/g, 'o')
-    .replace(/œ/g, 'oe')
-    .replace(/[ùúûü]/g, 'u')
-    .replace(/[ýÿ]/g, 'y');
+    if (text == null) return null;
+    return text
+        .toLowerCase()
+        .replace(/[àáâãäå]/g, 'a')
+        .replace(/æ/g, 'ae')
+        .replace(/ç/g, 'c')
+        .replace(/[èéêë]/g, 'e')
+        .replace(/[ìíîï]/g, 'i')
+        .replace(/ñ/g, 'n')
+        .replace(/[òóôõö]/g, 'o')
+        .replace(/œ/g, 'oe')
+        .replace(/[ùúûü]/g, 'u')
+        .replace(/[ýÿ]/g, 'y');
 }
 
 function contains(target, lookingFor) {
-  return target && target.indexOf(lookingFor) >= 0;
+    return target && target.indexOf(lookingFor) >= 0;
 }
 
 dagfuncs.myTextMatcher = ({value, filterText}) => {
-  const aliases = {
-    usa: "united states",
-    holland: "netherlands",
-    niall: "ireland",
-    sean: "south africa",
-    alberto: "mexico",
-    john: "australia",
-    xi: "china",
-  };
-  const literalMatch = contains(value, filterText || "");
-  return literalMatch || contains(value, aliases[filterText || ""]);
+    const aliases = {
+        usa: "united states",
+        holland: "netherlands",
+        niall: "ireland",
+        sean: "south africa",
+        alberto: "mexico",
+        john: "australia",
+        xi: "china",
+    };
+    const literalMatch = contains(value, filterText || "");
+    return literalMatch || contains(value, aliases[filterText || ""]);
+}
+
+dagfuncs.myNumberParser = (text) => {
+    return text === null ? null : parseFloat(text.replace(",", ".").replace("$", ""));
+}
+dagfuncs.myNumberFormatter = (value) => {
+    return value === null ? null : value.toString().replace(".", ",");
+}
+
+dagfuncs.startWith = ([filterValues], cellValue) => {
+    const name = cellValue ? cellValue.split(" ")[1] : ""
+    return name && name.toLowerCase().indexOf(filterValues.toLowerCase()) === 0
+}
+
+dagfuncs.quickFilterMatcher = (quickFilterParts, rowQuickFilterAggregateText) => {
+    return quickFilterParts.every(part => rowQuickFilterAggregateText.match(part));
 }

--- a/tests/examples/filter_params_custom_options.py
+++ b/tests/examples/filter_params_custom_options.py
@@ -1,0 +1,44 @@
+"""
+Example to test filterParams.filterOptions.predicate function
+"""
+
+import dash_ag_grid as dag
+from dash import Dash, html
+import pandas as pd
+
+app = Dash(__name__)
+
+df = pd.read_csv(
+    "https://raw.githubusercontent.com/plotly/datasets/master/ag-grid/olympic-winners.csv"
+)
+
+columnDefs = [
+    {
+        "field": "athlete",
+        "filterParams": {
+            "filterOptions": [
+                {
+                    "displayKey": 'nameStartsWith',
+                    "displayName": 'Name starts with',
+                    "predicate": {"function": "startWith"},
+                    "numberOfInputs": 1,
+                },
+            ],
+        },
+    },
+]
+
+app.layout = html.Div(
+    [
+        dag.AgGrid(
+            id="filter-conditions-custom-options",
+            rowData=df.to_dict("records"),
+            columnDefs=columnDefs,
+            defaultColDef={"flex": 1, "filter": True, "floatingFilter": True},
+            dashGridOptions={"animateRows": False}
+        ),
+    ]
+)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/tests/examples/filter_params_number.py
+++ b/tests/examples/filter_params_number.py
@@ -1,0 +1,41 @@
+"""
+Example to test filterParams.numberParser and filterParams.numberFormatter functions
+"""
+
+import dash_ag_grid as dag
+from dash import Dash, html
+
+app = Dash(__name__)
+
+rowData = [{"sale": (i - 3) * 100} for i in range(50)]
+
+columnDefs = [
+    {
+        "field": "sale",
+        "filter": "agNumberColumnFilter",
+        "filterParams": {
+            "filterOptions": ["greaterThan"],
+            "allowedCharPattern": "\\d\\-\\,\\$",
+            "numberParser": {"function": "myNumberParser(params)"},
+            "numberFormatter": {"function": "myNumberFormatter(params)"},
+        },
+        "valueFormatter": {
+            "function": "d3.formatLocale({'decimal': ',', 'thousands': '.', 'currency': ['$', '']}).format('$,.2f')(params.value)"
+        },
+    },
+]
+
+app.layout = html.Div(
+    [
+        dag.AgGrid(
+            id="filter-number",
+            columnDefs=columnDefs,
+            defaultColDef={"floatingFilter": True},
+            rowData=rowData,
+            columnSize="sizeToFit",
+        ),
+    ]
+)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/tests/examples/filter_params_text.py
+++ b/tests/examples/filter_params_text.py
@@ -1,4 +1,6 @@
-# Example to test textFormatter and filterParams functions in filterParams
+"""
+Example to test filterParams.textFormatter and filterParams.textMatcher functions
+"""
 
 import dash_ag_grid as dag
 from dash import Dash, html

--- a/tests/examples/filter_quick_filter.py
+++ b/tests/examples/filter_quick_filter.py
@@ -1,0 +1,55 @@
+"""
+Example to test dashGridOptions.quickFilterParser and filterParams.textMatcher functions
+"""
+
+import dash_ag_grid as dag
+from dash import Dash, html, dcc, callback, Input, Output, Patch
+import pandas as pd
+
+app = Dash(__name__)
+
+df = pd.read_csv(
+    "https://raw.githubusercontent.com/plotly/datasets/master/ag-grid/olympic-winners.csv"
+)
+
+columnDefs = [
+    {"field": "athlete"},
+    {"field": "age"},
+]
+
+app.layout = html.Div(
+    [
+        dcc.Input(id="quick-filter-input", placeholder="filter..."),
+        dag.AgGrid(
+            id="quick-filter",
+            rowData=df.to_dict("records"),
+            columnDefs=columnDefs,
+            dashGridOptions={
+                # allows to split by space (default) and ',' for the words to search
+                # 'michael phelps' works by default, now 'michael, phelps' or 'michael,phelps' also
+                "quickFilterParser": {"function": r"params.split(/[\s,]+/)"},
+                # allows to use regex in quick search, like 2[012] matching Age 20, 21 and 22
+                # defining in dashAgGridFunctions.js:
+                # dagfuncs.quickFilterMatcher = (quickFilterParts, rowQuickFilterAggregateText) = > {
+                #   return quickFilterParts.every(part= > rowQuickFilterAggregateText.match(part));
+                # }
+                "quickFilterMatcher": {"function": "quickFilterMatcher"}
+            }
+        ),
+    ]
+)
+
+
+@callback(
+    Output("quick-filter", "dashGridOptions"),
+    Input("quick-filter-input", "value"),
+    prevent_initial_call=True,
+)
+def update_filter(filter_value):
+    new_grid_option = Patch()
+    new_grid_option['quickFilterText'] = filter_value
+    return new_grid_option
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/tests/test_quick_filter.py
+++ b/tests/test_quick_filter.py
@@ -1,0 +1,76 @@
+from dash import Dash, html, dcc, callback, Input, Output, Patch
+import dash_ag_grid as dag
+import pandas as pd
+
+from . import utils
+
+
+def test_fi006_quick_filter(dash_duo):
+    app = Dash(__name__)
+    df = pd.read_csv(
+        "https://raw.githubusercontent.com/plotly/datasets/master/ag-grid/olympic-winners.csv"
+    )
+
+    columnDefs = [
+        {"field": "athlete"},
+        {"field": "age"},
+    ]
+
+    app.layout = html.Div(
+        [
+            dcc.Input(id="quick-filter-input", placeholder="filter..."),
+            dag.AgGrid(
+                id="quick-filter",
+                rowData=df.to_dict("records"),
+                columnDefs=columnDefs,
+                dashGridOptions={
+                    # allows to split by space (default) and ',' for the words to search
+                    # 'michael phelps' works by default, now 'michael, phelps' or 'michael,phelps' also
+                    "quickFilterParser": {"function": r"params.split(/[\s,]+/)"},
+                    # allows to use regex in quick search, like 2[012] matching Age 20, 21 and 22
+                    # defining in dashAgGridFunctions.js:
+                    # dagfuncs.quickFilterMatcher = (quickFilterParts, rowQuickFilterAggregateText) = > {
+                    #   return quickFilterParts.every(part= > rowQuickFilterAggregateText.match(part));
+                    # }
+                    "quickFilterMatcher": {"function": "quickFilterMatcher"}
+                }
+            ),
+        ]
+    )
+
+    @callback(
+        Output("quick-filter", "dashGridOptions"),
+        Input("quick-filter-input", "value"),
+        prevent_initial_call=True,
+    )
+    def update_filter(filter_value):
+        new_grid_option = Patch()
+        new_grid_option['quickFilterText'] = filter_value
+        return new_grid_option
+
+    # Tests ##################################################################
+
+    dash_duo.start_server(app)
+    grid = utils.Grid(dash_duo, "quick-filter")
+    grid.wait_for_cell_text(0, 0, "Michael Phelps")
+
+    quick_filter_input = dash_duo.find_element('#quick-filter-input')
+
+    # test quickFilterParser
+    quick_filter_input.send_keys("michael phelps")
+    grid.wait_for_cell_text(0, 0, "Michael Phelps")
+    dash_duo.clear_input(quick_filter_input)
+
+    quick_filter_input.send_keys("michael, phelps")
+    grid.wait_for_cell_text(0, 0, "Michael Phelps")
+    dash_duo.clear_input(quick_filter_input)
+
+    quick_filter_input.send_keys("michael,phelps")
+    grid.wait_for_cell_text(0, 0, "Michael Phelps")
+    dash_duo.clear_input(quick_filter_input)
+
+    # test quickFilterMatcher
+    quick_filter_input.send_keys("2[012]")
+    grid.wait_for_cell_text(0, 1, "22")
+    grid.wait_for_cell_text(1, 1, "21")
+    grid.wait_for_cell_text(2, 1, "20")


### PR DESCRIPTION
Changelog:
- Add quartz theme
- Modify ag-grid version to 31.0.1, only bug fixes
- Add properties:
  - `quickFilterParser` in GRID_MAYBE_FUNCTIONS
  - `quickFilterMatcher` in GRID_MAYBE_FUNCTIONS_NO_PARAMS
  - `numberFormatter` and `numberParser` in COLUMN_MAYBE_FUNCTIONS
- Move `predicate` from COLUMN_MAYBE_FUNCTIONS to COLUMN_MAYBE_FUNCTIONS_NO_PARAMS
